### PR TITLE
XDR-5434: Add an environment for Semantic Release

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment } }
+    environment: ${{ inputs.environment }}
     outputs:
       semver: ${{ steps.get-semver.outputs.semver }}
     steps:

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -6,6 +6,12 @@ on:
         required: true
       NPM_ACCESS_TOKEN:
         required: false
+    inputs:
+      environment:
+        description: The environment that this job references.
+        required: false
+        type: string
+        default: ''
     outputs:
       semver:
         description: The semantic version inferred from the commit history and assigned to the current commit hash.
@@ -13,6 +19,7 @@ on:
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment } }
     outputs:
       semver: ${{ steps.get-semver.outputs.semver }}
     steps:


### PR DESCRIPTION
This adds an input to the _semantic Release_ workflow: `environment`

It simply passes the value of that input to the jobs in this workflow.

@bmoseley-armor, @arledesma 